### PR TITLE
feat: Add AWS CLI to the devcontainer

### DIFF
--- a/.github/workflows/build-devcontainer-image.yml
+++ b/.github/workflows/build-devcontainer-image.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Prepare the image build
         id: prep
         run: |
-          DEVCONTAINER_VERSION="${GITHUB_SHA::8}"
+          DEVCONTAINER_VERSION="${GITHUB_SHA::7}"
           IMAGE_NAME="${{ env.IMAGE_REPOSITORY }}"
           echo ::set-output name=image_name::${IMAGE_NAME}
           echo ::set-output name=devcontainer_version::${DEVCONTAINER_VERSION}

--- a/tools/devcontainers/github-tools/.devcontainer/devcontainer.json
+++ b/tools/devcontainers/github-tools/.devcontainer/devcontainer.json
@@ -16,6 +16,9 @@
   "features": {
     // docker features must be specified in the developer facing
     // devcontainer.json for VS Code to properly mount the docker sockets.
+    "ghcr.io/devcontainers/features/aws-cli:1.0.5": {
+      "version": "2.8.12"
+    }
   },
 
   // The reference properties listed below are not used during the devcontainer


### PR DESCRIPTION
Fixes #6 

## Changelog

- Add AWS CLI to the devcontainer
- Set the length of the devcontainer tag to 7 chars instead of 8 to match GitHub standard

## Preview

```console
vscode@74e685591087:/workspaces/github-tools$ aws --version
aws-cli/2.8.12 Python/3.9.11 Linux/4.14.296-222.539.amzn2.x86_64 exe/x86_64.debian.11 prompt/off
```

It looks like this feature also adds the AWS Toolkit (VS Code extension).